### PR TITLE
Automatic Deployment to GitHub Pages on Main Branch Pushes

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -3,7 +3,7 @@ name: Deploy Main to GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
 
 permissions:
   contents: write

--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -1,0 +1,63 @@
+name: Deploy Main to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pages: write
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout main branch
+      uses: actions/checkout@v3
+
+    - name: Set up Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+
+    - name: Install mdBook
+      run: cargo install mdbook
+
+    - name: Prepare src directory
+      run: |
+        mkdir -p src/vulnerabilities
+        cp README.md src/SUMMARY.md
+        cp -r vulnerabilities/* src/vulnerabilities/
+        
+    - name: Build the book
+      run: mdbook build
+
+    - name: Checkout gh-pages branch
+      uses: actions/checkout@v3
+      with:
+        ref: gh-pages
+        path: gh-pages
+
+    - name: Copy built book to gh-pages
+      run: |
+        rm -rf gh-pages/docs
+        mkdir -p gh-pages/docs
+        cp -r book/* gh-pages/docs/
+
+    - name: Commit and push changes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cd gh-pages
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        if [ -n "$(git status --porcelain)" ]; then
+          git add docs
+          git commit -m 'Deploy new changes'
+          git push origin gh-pages
+        else
+          echo "No changes to commit"
+        fi


### PR DESCRIPTION
I created a GitHub workflow to automate the deployment of the documentation to GitHub Pages whenever changes are pushed to the main branch. This pr closes #28 

Here's a summary of the workflow:

Trigger: Runs on pushes to the main branch.
Permissions: Sets write permissions for contents and pages.
Jobs:
-   Checkout: Checks out the main branch.
-   Setup Rust: Sets up the Rust toolchain.
-   Install mdBook: Installs mdBook for building the documentation.
-   Prepare Source Directory: Prepares the src directory for mdBook.
-   Build the Book: Builds the documentation using mdBook.
-   Checkout gh-pages: Checks out the gh-pages branch.
-   Copy Built Book: Copies the built documentation to the gh-pages branch.
-   Commit and Push: Commits and pushes the changes to the gh-pages branch if there are any updates.

This ensures that the documentation is always up-to-date with the latest changes on the main branch.

I have already tested the workflow in my test repo, you can check [here](https://drive.google.com/file/d/1BSLRuWPaXPEDDyHQ9nsTtJijwedxdvre/view?usp=drive_link) 

