### PR TITLE
Update use-of-deprecated-functions.md

### DIFF
--- a/vulnerabilities/use-of-deprecated-functions.md
+++ b/vulnerabilities/use-of-deprecated-functions.md
@@ -6,6 +6,7 @@ Here is a *non-exhaustive* list of deprecated functions and alternatives. Many a
 
 | Deprecated              | Alternatives              |
 | :---------------------- | ------------------------: |
+| `suicide(address)`/`selfdestruct(address)` | N/A    | 
 | `block.blockhash(uint)` |	`blockhash(uint)`         |
 | `sha3(...)`	            | `keccak256(...)`          |
 | `callcode(...)`	        | `delegatecall(...)`       |

--- a/vulnerabilities/use-of-deprecated-functions.md
+++ b/vulnerabilities/use-of-deprecated-functions.md
@@ -6,7 +6,6 @@ Here is a *non-exhaustive* list of deprecated functions and alternatives. Many a
 
 | Deprecated              | Alternatives              |
 | :---------------------- | ------------------------: |
-| `suicide(address)`      |	`selfdestruct(address)`   |
 | `block.blockhash(uint)` |	`blockhash(uint)`         |
 | `sha3(...)`	            | `keccak256(...)`          |
 | `callcode(...)`	        | `delegatecall(...)`       |


### PR DESCRIPTION
- [✅] I have read and followed the [style guide](https://github.com/kadenzipfel/smart-contract-vulnerabilities/blob/master/style-guide.md)

Removed `selfdestruct(address)` as an alternative to `suicide(address)` as it was deprecated during the Shanghai Ethereum upgrade as called for by [EIP-6049](https://eips.ethereum.org/EIPS/eip-6049).

## Type of change

Select the appropriate checkbox:
- [✅] Documentation update (improving existing information)