### PR TITLE
Division before multiplication vulnerability added.

### DIFF
--- a/vulnerabilities/divide-before-multiply.md
+++ b/vulnerabilities/divide-before-multiply.md
@@ -1,0 +1,27 @@
+# Division before multiplication
+
+Solidity's integer division truncates. Thus, performing division before multiplication can lead to precision loss.
+```solidity
+contract A {
+	function func(uint n) public {
+        coins = (oldSupply / n) * interest; // causes precision loss
+    }
+}
+```
+If ``n`` is greater than ``oldSupply``, coins will be ``zero``. Also, the fractional part is truncated due to integer division in solidity. 
+```solidity
+1 / 3 = 0 // rounding to 0
+3 / 2 = 1 // 0.5 is truncated
+```
+
+Let's expand further,
+When ``oldSupply = 5; n = 10, interest = 2``, 
+if ``(oldSupply / n) * interest`` is used, coins value will round to ``zero``.
+and If ``(oldSupply * interest / n)`` is used, coins value will be ``1``.
+
+Similarly for larger values, 
+When `` oldSupply = 119, n = 10, interest = 10``, 
+if ``(oldSupply / n) * interest`` is used, coins value will be ``110`` 
+and if ``(oldSupply * interest / n)`` is used, coins value will be ``119``. 
+
+Here, ``9`` coins were lost due to division before multiplication but following multiplication before division gave the exact value of coins. Thus, multiplication before division can prevent loss of precision due to truncation.

--- a/vulnerabilities/mapping-within-struct.md
+++ b/vulnerabilities/mapping-within-struct.md
@@ -1,0 +1,21 @@
+# Deleting a mapping within a struct
+
+It is a common assumption that deleting ``struct`` will delete all of it's data entirely but there is an exception. Deleting structs that contain dynamic data types does not delete the dynamic data. For example: If a ``mapping`` (or dynamic array) is inside a struct, and the struct is deleted, the mapping or array will not be deleted. The remaining data may be used to compromise the contract.
+
+```solidity
+    struct BalancesStruct{
+        address owner;
+        mapping(address => uint) balances;
+    }
+
+    mapping(address => BalancesStruct) public stackBalance;
+
+    function remove() internal{
+         delete stackBalance[msg.sender]; // doesn't delete balances mapping
+    }
+```
+``remove()`` function above deletes an item of ``stackBalance``. The mapping ``balances`` is never deleted, so remove does not work as intended.
+
+
+## Sources
+- https://docs.soliditylang.org/en/latest/types.html#delete

--- a/vulnerabilities/overflow-underflow.md
+++ b/vulnerabilities/overflow-underflow.md
@@ -1,18 +1,74 @@
 ## Integer Overflow and Underflow
+In solidity, Integer types have maximum and minimum values. Integer overflow occurs when an integer variable exceeds the maximum value that can be stored in that variable type. Similarly, Integer underflow occurs when an integer variable goes below the minimum value for that variable type. Example: The maximum value ``uint8`` can store is ``255``. Now, when you store ``256`` in ``uint8`` it will overflow and the value will reset to 0. When you store ``257``, the value will be ``1``, ``2`` for ``258`` and so on. Similarly, if you try to store ``-1`` in the uint8 variable the value of the variable will become ``255``, and so on as it will underflow.
 
-In solidity, integer types have maximum values. For example:
+Some integer types and their min/max values:
+| Type   |      Max      |  Min |
+|----------|-------------|------|
+| uint8 |  255 | 0 |
+| uint16 | 65535 |   0 |
+| uint24 | 16777215 | 0 |
+| uint256 | 2^256 - 1 |  0 |
 
-`uint8` => 255
-`uint16` => 65535
-`uint24` => 16777215
-`uint256` => (2^256) - 1
+Since smaller integer types like: ``uint8``, ``uint16``, etc have smaller maximum values, it can be easier to cause an overflow, thus they should be used with greater caution.
 
-Overflow and underflow bugs can occur when you exceed the maximum value (overflow) or when you go below the minimum value (underflow). When you exceed the maximum value, you go back down to zero, and when you go below the minimum value, it brings you back up to the maximum value.
+To prevent over/underflows, [Safe Math Library](https://github.com/ConsenSysMesh/openzeppelin-solidity/blob/master/contracts/math/SafeMath.sol) is often used by contracts with older versions of Solidity but Solidity >=0.8 protects against integer overflows and underflows through the use of built-in safe math functions. It's important to consider that regardless of SafeMath logic being used, either built-in or used manually in older contracts, over/underflows still trigger reverts, which may result in [denial of service](https://github.com/kadenzipfel/smart-contract-vulnerabilities/blob/master/vulnerabilities/dos-revert.md) of important functionality or other unexpected effects. Even after the update of solidity to 0.8, there are scenarios in which the integer overflow and underflow can still occur without the transaction reverting.
 
-Since smaller integer types like: `uint8`, `uint16`, etc. have smaller maximum values, it can be easier to cause an overflow, thus they should be used with greater caution.
+### Typecasting
+The most common way in which integer over/underflow is possible when you convert an integer of a larger uint data type to a smaller data type.
+```solidity
+uint256 public a = 258;
+uint8 public b = uint8(a); // typecasting uint256 to uint8
+```
 
-Older contracts often made use of the [SafeMath library](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/math/SafeMath.sol), to avoid over/underflows, but in solidity >=v0.8.0, SafeMath logic is built in by default. It's important to consider that regardless of SafeMath logic being used, either built-in or used manually in older contracts, over/underflows still trigger reverts, which may result in [denial of service](./dos-revert.md) of important functionality or other unexpected effects. Built-in SafeMath logic may also be avoided with `unchecked` blocks, [see docs for more info](https://docs.soliditylang.org/en/v0.8.15/control-structures.html?highlight=unchecked#checked-or-unchecked-arithmetic).
+The above code snippet will overflow and the ``2`` will be stored in the variable ``b`` due to the fact that maximum value in uint8 data type is ``255``. So, it will overflow and reset to ``0`` without reverting.
 
-### Sources
+### Using Shift Operators
+Overflow & underflow checks are not performed for shift operations like they are performed for other arithmetic operations. Thus, over/underflows can occur.
 
-- https://consensys.github.io/smart-contract-best-practices/attacks/insecure-arithmetic/
+The left shift ``<<`` operator shifts all the beats in the first operand by the number specified in the second operand.Shifting an operand by 1 position is equivalent to multiplying it by 2, shifting 2 positions is equivalent to multiplying it by 4, and shifting 3 positions is equivalent to multiplying by 8. 
+
+```solidity
+uint8 public a = 100;
+uint8 public b = 2;
+
+uint8 public c = a << b; // overflow as 100 * 4 > 255
+```
+In the above code, left shifting ``a`` which is ``100`` by 2 positions ``b`` is equivalent to multiplying 100 by 4. So the result will overflow and the value in c will be ``144`` because ``400-256`` is ``144``.
+
+### Use of Inline Assembly:
+Inline Assembly in solidity is performed using YUL language. In YUL programming language, integer underflow & overflow is possible as compiler does not check automatically for it as YUL is a low-level language that is mostly used for making the code more optimized, which does this by omitting many opcodes.
+
+```solidity
+uint8 public a = 255;
+
+function addition() public returns (uint8 result) {
+
+assembly {
+result := add(sload(a.slot),1) // adding 1 will overflow and reset to 0
+// using inline assembly
+}
+
+return result;
+}
+```
+In the above code we are adding ``1`` into the variable with inline assembly and then returning the result. The variable result will overflow and 0 will be returned, despite this the contract will not throw an error or revert.
+
+### Use of unchecked code block:
+Performing arithmetic operations inside the unchecked block saves a lot of gas because it omits several checks and opcodes.But, some of these opcodes are used in default arithmetic operations in 0.8 to check for underflow/ overflow.
+
+```solidity
+uint8 public a = 255;
+
+function uncheck() public{
+
+  unchecked {
+      a++;  // overflow and reset to 0 without reverting
+  }
+
+}
+```
+The unchecked code block is only recommended if you are sure that there is no possible way for the arithmetic to overflow or underflow.
+
+## Sources
+1. https://docs.soliditylang.org/en/latest/080-breaking-changes.html
+2. https://faizannehal.medium.com/how-solidity-0-8-protect-against-integer-underflow-overflow-and-how-they-can-still-happen-7be22c4ab92f

--- a/vulnerabilities/overflow-underflow.md
+++ b/vulnerabilities/overflow-underflow.md
@@ -25,7 +25,7 @@ The above code snippet will overflow and the ``2`` will be stored in the variabl
 ### Using Shift Operators
 Overflow & underflow checks are not performed for shift operations like they are performed for other arithmetic operations. Thus, over/underflows can occur.
 
-The left shift ``<<`` operator shifts all the beats in the first operand by the number specified in the second operand.Shifting an operand by 1 position is equivalent to multiplying it by 2, shifting 2 positions is equivalent to multiplying it by 4, and shifting 3 positions is equivalent to multiplying by 8. 
+The left shift ``<<`` operator shifts all the beats in the first operand by the number specified in the second operand. Shifting an operand by 1 position is equivalent to multiplying it by 2, shifting 2 positions is equivalent to multiplying it by 4, and shifting 3 positions is equivalent to multiplying by 8. 
 
 ```solidity
 uint8 public a = 100;
@@ -42,19 +42,18 @@ Inline Assembly in solidity is performed using YUL language. In YUL programming 
 uint8 public a = 255;
 
 function addition() public returns (uint8 result) {
+    assembly {
+        result := add(sload(a.slot), 1) // adding 1 will overflow and reset to 0
+        // using inline assembly
+    }
 
-assembly {
-result := add(sload(a.slot),1) // adding 1 will overflow and reset to 0
-// using inline assembly
-}
-
-return result;
+    return result;
 }
 ```
 In the above code we are adding ``1`` into the variable with inline assembly and then returning the result. The variable result will overflow and 0 will be returned, despite this the contract will not throw an error or revert.
 
 ### Use of unchecked code block:
-Performing arithmetic operations inside the unchecked block saves a lot of gas because it omits several checks and opcodes.But, some of these opcodes are used in default arithmetic operations in 0.8 to check for underflow/ overflow.
+Performing arithmetic operations inside the unchecked block saves a lot of gas because it omits several checks and opcodes. But, some of these opcodes are used in default arithmetic operations in 0.8 to check for underflow/overflow.
 
 ```solidity
 uint8 public a = 255;


### PR DESCRIPTION
## Related Issue

- Closes: https://github.com/kadenzipfel/smart-contract-vulnerabilities/issues/74

## Checklist

- [x] I have read and followed the [style guide](https://github.com/kadenzipfel/smart-contract-vulnerabilities/blob/master/style-guide.md)

### Describe the changes you've made:

This contribution adds a vulnerability that exploits solidity integer division which causes fractional loss due to truncation. I think we can create a new category called ``Solidity Math Issues`` which includes all the issues involving solidity math like divide by zero, rounding errors, rounding to 0, loss of precision, solidity truncation, etc in a single listing.

## Type of change

Select the appropriate checkbox:

- [ ] Bug fix (fixing an issue with existing vulnerability data)
- [x] New feature (adding a new vulnerability or category)
- [ ] Documentation update (improving existing information)

## Additional Information
I think the example I presented here is not formatted properly. Let me hear your recommendations and I will make changes accordingly.